### PR TITLE
Lisätty frontend+backendin yhtäaikaisen ajon skripti

### DIFF
--- a/start_dev.sh
+++ b/start_dev.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Start the backend service
+startBackend() {
+    cd backend && ./gradlew build && java -jar build/libs/backend-0.0.1-SNAPSHOT.jar && cd ..
+}
+
+# Start the frontend service
+startFrontend(){
+    cd frontend && npm run dev && cd .. 
+}
+
+# Wait for all services to start, kill with CTRL+C
+startFrontend & startBackend; trap "exit" SIGINT; wait


### PR DESCRIPTION
This pull request introduces a new script, `start_dev.sh`, to streamline the development workflow by allowing developers to start both the backend and frontend services with a single command. The script also includes error handling and process management for a smoother experience.

**Development workflow improvements:**

* Added a Bash script `start_dev.sh` that starts both the backend (via Gradle build and running the JAR) and frontend (via `npm run dev`) services concurrently, simplifying the process of running the application in development mode.
* Included error handling (`set -e`) to ensure the script exits if any command fails, improving reliability during startup.
* Implemented process management so both services run in the background and can be terminated together using CTRL+C (`trap "exit" SIGINT; wait`).