### PR TITLE
issue/#230-selvita-onnistuuko-pelkan-backendin-deployment-herokuun

### DIFF
--- a/backend/system.properties
+++ b/backend/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=21


### PR DESCRIPTION
This pull request sets the Java runtime version to 21 in `backend/system.properties` file so Heroku knows which Java version to use.