### PR TITLE
Issue/#229 Spring Booting pitäisi antaa viesti kun backend on buildattu

### DIFF
--- a/backend/src/main/java/fi/fisma/backend/BackendApplication.java
+++ b/backend/src/main/java/fi/fisma/backend/BackendApplication.java
@@ -8,5 +8,8 @@ public class BackendApplication {
 
   public static void main(String[] args) {
     SpringApplication.run(BackendApplication.class, args);
+    System.out.println("\n===============================");
+    System.out.println("SPRING BOOT APPLICATION STARTED");
+    System.out.println("===============================\n");
   }
 }


### PR DESCRIPTION
This pull request makes a small change to the application startup process by adding a console message indicating when the Spring Boot application has started. This helps with visibility during development and troubleshooting. As it is added to `@SpringBootApplication`, it applies to every method to start the backend server: Docker, Gradle `bootRun`, or Gradle `build` + running built .jar file.