### PR TITLE
Issue/#285 Tulosteessa komponentit ovat englanniksi

### DIFF
--- a/frontend/src/components/FunctionalPointSummary.tsx
+++ b/frontend/src/components/FunctionalPointSummary.tsx
@@ -102,6 +102,17 @@ export const FunctionalPointSummary = ({
   const totalPoints = calculateTotalFunctionalComponentPoints(
     project.functionalComponents,
   );
+
+  const handleExportPdf = () => {
+    createPdf(
+      project,
+      previousOrCurrent,
+      translation.printUtils,
+      translation.functionalClassComponent.classNameOptions,
+      translation.functionalClassComponent.componentTypeOptions,
+    );
+  };
+
   return (
     <div className="flex flex-col border-2 p-4 bg-white h-[calc(55vh-5rem)] overflow-y-auto sticky top-20">
       <div className="max-h-[60vh] overflow-y-auto pr-2">
@@ -177,9 +188,7 @@ export const FunctionalPointSummary = ({
           CSV <FontAwesomeIcon icon={faDownload} />
         </button>
         <button
-          onClick={() =>
-            createPdf(project, previousOrCurrent, translation.printUtils)
-          }
+          onClick={handleExportPdf}
           className="px-4 py-2 bg-fisma-blue hover:bg-fisma-dark-blue text-white cursor-pointer text-sm sm:text-base"
         >
           PDF <FontAwesomeIcon icon={faDownload} />

--- a/frontend/src/lib/printUtils.ts
+++ b/frontend/src/lib/printUtils.ts
@@ -93,26 +93,9 @@ const calculateTotalFunctionalComponentPoints = (
 export const createPdf = (
   project: Project,
   oldProject: Project,
-  translation: {
-    projectReport: string;
-    projectId: string;
-    version: string;
-    createdDate: string;
-    versionCreatedDate: string;
-    lastEditedDate: string;
-    className: string;
-    componentType: string;
-    dataElements: string;
-    readingReferences: string;
-    writingReferences: string;
-    functionalMultiplier: string;
-    operations: string;
-    degreeOfCompletion: string;
-    functionalPoints: string;
-    title: string;
-    description: string;
-    totalFunctionalPoints: string;
-  },
+  printUtilsTranslation: Record<string, string> = {},
+  classNameTranslation: Record<string, string> = {},
+  componentTypeTranslation: Record<string, string> = {},
 ) => {
   // Maps functional components for previous project so that they can be compared to the current project
   const previousComponentsMap = Object.fromEntries(
@@ -122,7 +105,7 @@ export const createPdf = (
   const pdfContent = `
     <html>
       <head>
-        <title>${translation.projectReport}</title>
+        <title>${printUtilsTranslation.projectReport}</title>
         <style>
           .project-data {
             font-weight: normal;
@@ -141,26 +124,26 @@ export const createPdf = (
         </style>
       </head>
       <body>
-        <h1>${translation.projectReport}: ${project.projectName}</h1>
+        <h1>${printUtilsTranslation.projectReport}: ${project.projectName}</h1>
         <div class="project-info">
-          <p><strong>${translation.projectId}:</strong> ${valueComparer(project.id, oldProject.id)}</p>
-          <p><strong>${translation.version}:</strong> ${valueComparer(project.version, oldProject.version)}</p>
-          <p><strong>${translation.createdDate}:</strong> ${valueComparer(dateLocalizer(project.createdDate), dateLocalizer(oldProject.createdDate))}</p>
-          <p><strong>${translation.versionCreatedDate}:</strong> ${valueComparer(dateLocalizer(project.versionDate), dateLocalizer(oldProject.versionDate))}</p>
-          <p><strong>${translation.lastEditedDate}:</strong> ${valueComparer(dateLocalizer(project.editedDate), dateLocalizer(oldProject.editedDate))}</p>
+          <p><strong>${printUtilsTranslation.projectId}:</strong> ${valueComparer(project.id, oldProject.id)}</p>
+          <p><strong>${printUtilsTranslation.version}:</strong> ${valueComparer(project.version, oldProject.version)}</p>
+          <p><strong>${printUtilsTranslation.createdDate}:</strong> ${valueComparer(dateLocalizer(project.createdDate), dateLocalizer(oldProject.createdDate))}</p>
+          <p><strong>${printUtilsTranslation.versionCreatedDate}:</strong> ${valueComparer(dateLocalizer(project.versionDate), dateLocalizer(oldProject.versionDate))}</p>
+          <p><strong>${printUtilsTranslation.lastEditedDate}:</strong> ${valueComparer(dateLocalizer(project.editedDate), dateLocalizer(oldProject.editedDate))}</p>
         </div>
         <table>
           <tr>
-            <th>${translation.className}</th>
-            <th>${translation.componentType}</th>
-            <th>${translation.dataElements}</th>
-            <th>${translation.readingReferences}</th>
-            <th>${translation.writingReferences}</th>
-            <th>${translation.operations}</th>
-            <th>${translation.degreeOfCompletion}</th>
-            <th>${translation.functionalPoints}</th>
-            <th>${translation.title}</th>
-            <th>${translation.description}</th>
+            <th>${printUtilsTranslation.className}</th>
+            <th>${printUtilsTranslation.componentType}</th>
+            <th>${printUtilsTranslation.dataElements}</th>
+            <th>${printUtilsTranslation.readingReferences}</th>
+            <th>${printUtilsTranslation.writingReferences}</th>
+            <th>${printUtilsTranslation.operations}</th>
+            <th>${printUtilsTranslation.degreeOfCompletion}</th>
+            <th>${printUtilsTranslation.functionalPoints}</th>
+            <th>${printUtilsTranslation.title}</th>
+            <th>${printUtilsTranslation.description}</th>
           </tr>
           ${project.functionalComponents
             .map((comp) => {
@@ -174,8 +157,22 @@ export const createPdf = (
 
               return `
             <tr>
-              <td>${valueComparer(comp.className, prevComp?.className || null)}</td>
-              <td>${valueComparer(comp.componentType, prevComp?.componentType || null)}</td>
+              <td>${valueComparer(
+                classNameTranslation[comp.className],
+                prevComp?.className
+                  ? classNameTranslation[prevComp?.className]
+                  : null,
+              )}</td>
+              <td>${valueComparer(
+                comp.componentType
+                  ? componentTypeTranslation[comp.componentType] ||
+                      comp.componentType
+                  : null,
+                prevComp?.componentType
+                  ? componentTypeTranslation[prevComp.componentType] ||
+                      prevComp.componentType
+                  : null,
+              )}</td>
               <td>${valueComparer(comp.dataElements, prevComp?.dataElements || null)}</td>
               <td>${valueComparer(comp.readingReferences, prevComp?.readingReferences || null)}</td>
               <td>${valueComparer(comp.writingReferences, prevComp?.writingReferences || null)}</td>
@@ -197,7 +194,7 @@ export const createPdf = (
             })
             .join("")}
           <tr class="total-row">
-            <td colspan="8"><b>${translation.totalFunctionalPoints}</b></td>
+            <td colspan="8"><b>${printUtilsTranslation.totalFunctionalPoints}</b></td>
             <td colspan="2"><b>${valueComparer(calculateTotalFunctionalComponentPoints(project.functionalComponents).toFixed(2), calculateTotalFunctionalComponentPoints(oldProject.functionalComponents).toFixed(2))}</b></td>
           </tr>
         </table>

--- a/frontend/src/lib/translations.ts
+++ b/frontend/src/lib/translations.ts
@@ -185,7 +185,7 @@ export const translations = {
       createdDate: "Luotu",
       versionCreatedDate: "Versio Luotu",
       lastEditedDate: "Muokattu",
-      className: "Toiminto-\nluokka",
+      className: "Toimintoluokka",
       componentType: "Toiminto-\ntyyppi",
       dataElements: "Tieto-\nelementit",
       readingReferences: "Luku-\nviittaukset",


### PR DESCRIPTION
This pull request improves the PDF export functionality for functional component summaries by enhancing translation support and making the code more maintainable. The main changes involve updating how translations are passed to the PDF generation utility, allowing for more granular and flexible localization, and improving the display of translated values in the exported PDF.

NOTE: `printUtils.ts` lines 160-175 take the possible null values into account by using ternary operators.

NOTE FOR FUTURE: it might be a good idea (but veeeeery tedious) to refactor the whole app to use a proper translation library such as `i18next`, need to discuss this with Heikki.

**Enhancements to PDF Export and Translation:**

* Refactored the `createPdf` function in `printUtils.ts` to accept separate translation objects for general labels, class names, and component types, instead of a single, tightly-typed translation object. This makes it easier to maintain and extend translations.
* Updated the PDF table generation to use the new translation objects, ensuring that class names and component types are displayed using localized values in the exported PDF.
* Modified all usages of translation variables in the PDF content to use the new `printUtilsTranslation` object, improving consistency and future-proofing the code for additional languages or changes. [[1]](diffhunk://#diff-30490a2858f188b19a8b449fc955d5f8d69bb67bf75263ad730b1ba6cf969b98L125-R108) [[2]](diffhunk://#diff-30490a2858f188b19a8b449fc955d5f8d69bb67bf75263ad730b1ba6cf969b98L144-R146) [[3]](diffhunk://#diff-30490a2858f188b19a8b449fc955d5f8d69bb67bf75263ad730b1ba6cf969b98L200-R197)

**UI and Integration Updates:**

* Updated the `FunctionalPointSummary` component to use a new `handleExportPdf` function, which passes the correct translation objects to `createPdf`, ensuring the PDF export button works with the updated translation handling. [[1]](diffhunk://#diff-b7c2690fac464973d3dd9bd89fcae92c5bb9506e32235a1d9ee5aad97e213d77R105-R115) [[2]](diffhunk://#diff-b7c2690fac464973d3dd9bd89fcae92c5bb9506e32235a1d9ee5aad97e213d77L180-R191)

**Translation Corrections:**

* Fixed a minor translation issue in the Finnish translation for "className" to remove unnecessary line breaks, improving the appearance of exported PDFs.