### PR TITLE
issue/#300-versiointi-on-sekava

### DIFF
--- a/frontend/src/components/ProjectPage.tsx
+++ b/frontend/src/components/ProjectPage.tsx
@@ -353,6 +353,15 @@ export default function ProjectPage() {
                 {collapseAll ? translation.expandAll : translation.collapseAll}
               </button>
             </div>
+            {isLatest ? (
+              <div className="text-center font-medium mt-1">
+                {translation.currentlyEditingVersion} {project?.version}
+              </div>
+            ) : (
+              <div className="text-center font-medium mt-1 text-red-600">
+                {translation.cannotEditSavedVersion} {project?.version}
+              </div>
+            )}
             <div className="flex flex-row gap-2 w-full">
               <button
                 className={`w-full ${

--- a/frontend/src/lib/translations.ts
+++ b/frontend/src/lib/translations.ts
@@ -124,7 +124,7 @@ export const translations = {
       saveProject: "Save",
       newFunctionalComponent: "New Functional Component",
       noProject: "No project information to show!",
-      saveProjectAsVersion: "Save version ",
+      saveProjectAsVersion: "Save as version ",
       saveVersionWarningBeginning:
         "Are you sure you want to save the project as version",
       saveVersionWarningEnd: "Older versions cannot be modified.",
@@ -132,6 +132,8 @@ export const translations = {
       selectProjectVersion: "Select Project Version",
       version: "Version",
       nameOfProject: "Project name",
+      currentlyEditingVersion: "Currently editing version",
+      cannotEditSavedVersion: "Cannot edit saved version",
       expandAll: "Expand all",
       collapseAll: "Collapse all",
       noFunctionalComponents:
@@ -280,6 +282,8 @@ export const translations = {
       selectProjectVersion: "Valitse Projektiversio",
       version: "Versio",
       nameOfProject: "Projektin nimi",
+      currentlyEditingVersion: "Muokataan versiota",
+      cannotEditSavedVersion: "Ei voi muokata tallennettua versiota",
       expandAll: "Laajenna kaikki",
       collapseAll: "Pienennä kaikki",
       noFunctionalComponents:


### PR DESCRIPTION
This pull request enhances the user experience on the project page by providing clearer feedback about which project version is being edited and restricting edits to saved versions. It also improves translation support for these new messages in both English and Finnish.

User interface improvements:

* Added a message to `ProjectPage.tsx` that displays whether the user is editing the latest version or a saved (non-editable) version, with appropriate styling and version information.

Translation updates:

* Added new translation keys `currentlyEditingVersion` and `cannotEditSavedVersion` in both English and Finnish, and refined the wording of `saveProjectAsVersion` for clarity. [[1]](diffhunk://#diff-63f05097c4a548b2bc2106f45ca89b7986d834aaddc361c23ea8b1850c2e59b6L127-R136) [[2]](diffhunk://#diff-63f05097c4a548b2bc2106f45ca89b7986d834aaddc361c23ea8b1850c2e59b6R285-R286)