### PR TITLE
chore/fix-package-lock-problems

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2250,7 +2250,6 @@
       "integrity": "sha512-icUt1NvfhGLar5lSWH3tHNzablaA5js3HVHacQimfP8ViEBOQv+L7DKEuHdbTZ0SKCO1ogTJTIL1Gwk9S6Qvcg==",
       "dev": true,
       "license": "ISC"
-      "dev": true
     },
     "node_modules/email-addresses": {
       "version": "5.0.0",
@@ -3321,7 +3320,6 @@
       "integrity": "sha512-4auku8B/vw5psvTiiN9j1dAOsXvMoGqJuKJcR+dTdqiXEK20mMTk1UEo3HS16LeGQsVG6+qKTPM9u/qQ2LqATA==",
       "dev": true,
       "license": "MIT"
-      "dev": true
     },
     "node_modules/object-assign": {
       "version": "4.1.1",


### PR DESCRIPTION
This pull request contains a minor update to the `frontend/package-lock.json` file. The change removes a duplicate `"dev": true` property from two package entries, which helps clean up the lock file and ensures proper formatting.