### PR TITLE
Chore/Fix tag creation workflow

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -10,9 +10,9 @@ permissions:
 
 jobs:
   create-tag:
-    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'chore/update-version-to-')
     name: Create a tag
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'chore/update-version-to-')
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This pull request makes a minor adjustment to the workflow configuration by moving the conditional statement for the `create-tag` job in `.github/workflows/create-release-tag.yml`. The condition now appears after the `runs-on` key instead of before the job name, which aligns with GitHub Actions syntax requirements.

It is not possible to skip the workflow from running on merges to `main`, but the workflow skips the tag creation job if the correct branch (`chore/update-version-to-*` created by version update script) is not merged. In normal development, nothing happens and no tags are created but the workflow still appears in GitHub Actions as "skipped".

Having this kind of workflow could be a good thing if in the future the developers want to create tags from every push to `main`. The current workflow file is easily modifiable to enable this.