### PR TITLE
chore/Update database seeding files

### DIFF
--- a/backend/src/main/resources/database-seed-dev.sql
+++ b/backend/src/main/resources/database-seed-dev.sql
@@ -34,12 +34,14 @@ INSERT INTO functional_components (
     order_position,
     is_mla,
     parent_fc_id,
+    sub_component_type,
+    is_readonly,
     project_id,
     deleted_at
 )
-VALUES  (1, 'Hakijan syöte', 'Kenttä hakijan syötteelle', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.12, NULL, 1, FALSE, NULL, 1, NULL),
-        (2, 'Lukumäärän valintapainike', 'Valintapainike lukumäärälle', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.34, 1, 2, FALSE, NULL, 2, NULL),
-        (3, 'Lähetä-painike', 'Painikkeella käyttäjä lähettää tiedot', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.5, 2, 3, FALSE, NULL, 1, NULL);
+VALUES  (1, 'Hakijan syöte', 'Kenttä hakijan syötteelle', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.12, NULL, 1, FALSE, NULL, NULL, FALSE, 1, NULL),
+        (2, 'Lukumäärän valintapainike', 'Valintapainike lukumäärälle', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.34, 1, 2, FALSE, NULL, NULL, FALSE, 2, NULL),
+        (3, 'Lähetä-painike', 'Painikkeella käyttäjä lähettää tiedot', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.5, 2, 3, FALSE, NULL, NULL, FALSE, 1, NULL);
 
 INSERT INTO projects_app_users (id, project_id, app_user_id)
 VALUES  (1, 1, 1),

--- a/backend/src/main/resources/database-seed-production.sql
+++ b/backend/src/main/resources/database-seed-production.sql
@@ -34,12 +34,14 @@ INSERT INTO functional_components (
     order_position,
     is_mla,
     parent_fc_id,
+    sub_component_type,
+    is_readonly,
     project_id,
     deleted_at
 )
-VALUES  (1, 'Hakijan syöte', 'Kenttä hakijan syötteelle', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.12, NULL, 1, FALSE, NULL, 1, NULL),
-        (2, 'Lukumäärän valintapainike', 'Valintapainike lukumäärälle', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.34, 1, 2, FALSE, NULL, 2, NULL),
-        (3, 'Lähetä-painike', 'Painikkeella käyttäjä lähettää tiedot', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.5, 2, 3, FALSE, NULL, 1, NULL);
+VALUES  (1, 'Hakijan syöte', 'Kenttä hakijan syötteelle', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.12, NULL, 1, FALSE, NULL, NULL, FALSE, 1, NULL),
+        (2, 'Lukumäärän valintapainike', 'Valintapainike lukumäärälle', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.34, 1, 2, FALSE, NULL, NULL, FALSE, 2, NULL),
+        (3, 'Lähetä-painike', 'Painikkeella käyttäjä lähettää tiedot', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.5, 2, 3, FALSE, NULL, NULL, FALSE, 1, NULL);
 
 INSERT INTO projects_app_users (id, project_id, app_user_id)
 VALUES  (1, 1, 1),

--- a/backend/src/main/resources/database-seed-testing.sql
+++ b/backend/src/main/resources/database-seed-testing.sql
@@ -59,12 +59,14 @@ INSERT INTO functional_components (
     order_position,
     is_mla,
     parent_fc_id,
+    sub_component_type,
+    is_readonly,
     project_id,
     deleted_at
 )
-VALUES  (1, 'Hakijan syöte', 'Kenttä hakijan syötteelle', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.12, NULL, 1, FALSE, NULL, 1, NULL),
-        (2, 'Lukumäärän valintapainike', 'Valintapainike lukumäärälle', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.34, 1, 2, FALSE, NULL, 2, NULL),
-        (3, 'Lähetä-painike', 'Painikkeella käyttäjä lähettää tiedot', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.5, 2, 3, FALSE, NULL, 1, NULL);
+VALUES  (1, 'Hakijan syöte', 'Kenttä hakijan syötteelle', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.12, NULL, 1, FALSE, NULL, NULL, FALSE, 1, NULL),
+        (2, 'Lukumäärän valintapainike', 'Valintapainike lukumäärälle', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.34, 1, 2, FALSE, NULL, NULL, FALSE, 2, NULL),
+        (3, 'Lähetä-painike', 'Painikkeella käyttäjä lähettää tiedot', 'Interactive end-user input service', '1-functional', 2, 4, 2, NULL, 3, 0.5, 2, 3, FALSE, NULL, NULL, FALSE, 1, NULL);
 
 INSERT INTO projects_app_users (id, project_id, app_user_id)
 VALUES  (1, 1, 1),


### PR DESCRIPTION
This pull request updates the seed data for the `functional_components` table across the development, testing, and production environments. The main change is the addition of two new columns, `sub_component_type` and `is_readonly`, to the table and the corresponding update of the seed data to include values for these new fields.

**Database schema and seed data updates:**

* Added `sub_component_type` and `is_readonly` columns to the `functional_components` insert statements in the seed files, and updated the seed data to provide values for these new columns. (`backend/src/main/resources/database-seed-dev.sql` [[1]](diffhunk://#diff-735c6712ead3cce1424d973137210675fa6471230acd1a2f95b6f73380b8a812R37-R44) `backend/src/main/resources/database-seed-production.sql` [[2]](diffhunk://#diff-1afffec1ded5e586ba14141ef1695b188a283a07791d4b940104b2b43382192bR37-R44) `backend/src/main/resources/database-seed-testing.sql` [[3]](diffhunk://#diff-8f1770ae9d55e466399a7f2208c8f185f7363b0b0709a4ceab5cdacaddf75f6eR62-R69)