### PR TITLE
issue/#407 Jos ei ole monikerrosliittymiä, yhteenvetolaatikossa tulee olla vain yksi progress bar

### DIFF
--- a/frontend/src/components/FunctionalPointSummary.tsx
+++ b/frontend/src/components/FunctionalPointSummary.tsx
@@ -435,35 +435,39 @@ export const FunctionalPointSummary = ({
         )}
       </div>
 
-      {/* Parent Components Only Progress Bar */}
-      <div className="w-full mb-4 mt-4">
-        <div className="flex justify-between text-xs font-medium text-gray-600">
-          <span>
-            {translation.functionalPointSummary.parentComponents}:{" "}
-            {parentOnlyPoints.toFixed(2)}{" "}
-            {translation.functionalPointSummary.functionalPointText} (
-            {parentOnlyPossiblePoints > 0
-              ? ((parentOnlyPoints / parentOnlyPossiblePoints) * 100).toFixed(1)
-              : "0.0"}
-            %)
-          </span>
-          <span>
-            {parentOnlyPossiblePoints.toFixed(2)}{" "}
-            {translation.functionalPointSummary.functionalPointText} (100%)
-          </span>
+      {/* Parent Components Only Progress Bar if MLA has been selected to any component */}
+      {hasMLA && (
+        <div className="w-full mb-4 mt-4">
+          <div className="flex justify-between text-xs font-medium text-gray-600">
+            <span>
+              {translation.functionalPointSummary.parentComponents}:{" "}
+              {parentOnlyPoints.toFixed(2)}{" "}
+              {translation.functionalPointSummary.functionalPointText} (
+              {parentOnlyPossiblePoints > 0
+                ? ((parentOnlyPoints / parentOnlyPossiblePoints) * 100).toFixed(
+                    1,
+                  )
+                : "0.0"}
+              %)
+            </span>
+            <span>
+              {parentOnlyPossiblePoints.toFixed(2)}{" "}
+              {translation.functionalPointSummary.functionalPointText} (100%)
+            </span>
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-2 mt-1">
+            <div
+              className="bg-blue-400 h-2 rounded-full"
+              style={{
+                width:
+                  parentOnlyPossiblePoints > 0
+                    ? `${(parentOnlyPoints / parentOnlyPossiblePoints) * 100}%`
+                    : "0%",
+              }}
+            />
+          </div>
         </div>
-        <div className="w-full bg-gray-200 rounded-full h-2 mt-1">
-          <div
-            className="bg-blue-400 h-2 rounded-full"
-            style={{
-              width:
-                parentOnlyPossiblePoints > 0
-                  ? `${(parentOnlyPoints / parentOnlyPossiblePoints) * 100}%`
-                  : "0%",
-            }}
-          />
-        </div>
-      </div>
+      )}
 
       {/* Grand Total Progress Bar (More Prominent) */}
       <div className="w-full border-t-2 border-gray-300 pt-3">


### PR DESCRIPTION
This pull request introduces a conditional display for the "Parent Components Only Progress Bar" in the `FunctionalPointSummary` component, ensuring it only appears if MLA has been selected for any component. This improves the user interface by showing relevant information only when applicable.

UI behavior improvements:

* The "Parent Components Only Progress Bar" in `FunctionalPointSummary.tsx` is now conditionally rendered based on the `hasMLA` flag, so it appears only when MLA is selected for any component. [[1]](diffhunk://#diff-b7c2690fac464973d3dd9bd89fcae92c5bb9506e32235a1d9ee5aad97e213d77L438-R449) [[2]](diffhunk://#diff-b7c2690fac464973d3dd9bd89fcae92c5bb9506e32235a1d9ee5aad97e213d77R470)