### PR TITLE
Bugfix: 405 - Ei anna kirjautua ulos väärällä JWT:llä

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -68,10 +68,9 @@ const Header = () => {
   const tryLogout = () => {
     if (
       sessionStorage.getItem("loginToken") !== sessionToken ||
-      sessionStorage.getItem("loginToken") === null
+      sessionStorage.getItem("loginToken") === null ||
+      sessionStorage.getItem("loginToken") === ""
     ) {
-      console.log(sessionStorage.getItem("loginToken"));
-      console.log(sessionToken);
       setLoggedIn(false);
       navigate("/login");
     } else {


### PR DESCRIPTION
Fix bug where logout with invalid JWT token causes loading loop. Add tryLogout function to Header.tsx to check if token is valid before logging out.