### PR TITLE
Bugfix/#405 benefit ei anna kirjautua ulos väärällä JWT:lla

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -17,7 +17,14 @@ import useTranslations from "../hooks/useTranslations";
 
 const Header = () => {
   const navigate = useNavigate();
-  const { appUser, loggedIn, logout, setLoggedIn, sessionToken } = useAppUser();
+  const {
+    appUser,
+    loggedIn,
+    logout,
+    setLoggedIn,
+    setSessionToken,
+    setAppUser,
+  } = useAppUser();
   const [isProjectModalOpen, setProjectModalOpen] = useState(false);
   const [isConfirmModalOpen, setConfirmModalOpen] = useState(false);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -65,15 +72,24 @@ const Header = () => {
     setMobileMenuOpen(false);
   };
 
-  const tryLogout = () => {
-    if (
-      sessionStorage.getItem("loginToken") !== sessionToken ||
-      sessionStorage.getItem("loginToken") === null
-    ) {
+  // Try logout from appUserProvider, if it fails, force the logout (user should always be able to log out).
+  // if the token is corrupted/expired, it doesn't need to be blacklisted so forcing the logout without it is ok.
+  const tryLogout = async () => {
+    try {
+      await logout();
+    } catch (error: unknown) {
+      // Reset session storage
+      sessionStorage.removeItem("loginToken");
+      sessionStorage.removeItem("userInfo");
+      sessionStorage.removeItem("userId");
+
+      // Reset app state
+      setSessionToken(null);
+      setAppUser(null);
       setLoggedIn(false);
+
+      //Navigate to login page
       navigate("/");
-    } else {
-      logout();
     }
   };
 

--- a/frontend/src/context/AppUserProvider.tsx
+++ b/frontend/src/context/AppUserProvider.tsx
@@ -29,8 +29,10 @@ const AppUserProvider = ({ children }: AppUserProviderProps) => {
 
     if (!response.ok) {
       if (response.status === 401) {
+        setLoadingAuth(false); //If the response is ok, stop loading --> not stuck in a loading loop
         throw new Error("Unauthorized!");
       } else {
+        setLoadingAuth(false);
         throw new Error(`Error logging out! Status: ${response.status}`);
       }
     }


### PR DESCRIPTION
Tein Headeriin virheenhallinnan, joka varmistaa, että käyttäjä pystyy kirjautumaan ulos myös väärällä JWT:llä. Korjasin myös ikuisen loading loopin varmistamalla, että appUserProviderin logout funktio laittaa latausanimaation pois päältä virheen sattuessa.