### PR TITLE
fix degreeOfCompletion able to be 0

### DIFF
--- a/frontend/src/components/FunctionalClassComponent.tsx
+++ b/frontend/src/components/FunctionalClassComponent.tsx
@@ -110,6 +110,7 @@ export default function FunctionalClassComponent({
     : fullPoints;
 
   const degreeOfCompletionOptions = new Map([
+    ["0", translation.degreeOfCompletion.notStarted],
     ["0.1", translation.degreeOfCompletion.specified],
     ["0.3", translation.degreeOfCompletion.planned],
     ["0.7", translation.degreeOfCompletion.implemented],
@@ -339,7 +340,7 @@ export default function FunctionalClassComponent({
                 <input
                   id="degreeOfCompletion"
                   type="number"
-                  min={0.01}
+                  min={0.0}
                   max={1}
                   step={0.01}
                   value={component.degreeOfCompletion ?? ""}

--- a/frontend/src/lib/fc-service-functions.ts
+++ b/frontend/src/lib/fc-service-functions.ts
@@ -40,7 +40,7 @@ export const getInputFields = (className: ClassName) => {
 };
 
 export const getClosestCompletionOption = (degree: number): string => {
-  if (degree === 0) return ""; // 0.0 -> show placeholder text
+  if (degree === 0.0) return "0.0"; // 0.0 -> not started
   if (degree >= 0.01 && degree <= 0.29) return "0.1"; // 0.01-0.29 → specified
   if (degree >= 0.3 && degree <= 0.69) return "0.3"; // 0.3-0.69 → planned
   if (degree >= 0.7 && degree <= 0.89) return "0.7"; // 0.7-0.89 → implemented

--- a/frontend/src/lib/translations.ts
+++ b/frontend/src/lib/translations.ts
@@ -143,6 +143,7 @@ export const translations = {
         "Enter a value between 0 and 1 (e.g. 0.75 = 75% complete)",
       confirmDeleteMessage: "Are you sure you want to delete component",
       degreeOfCompletion: {
+        notStarted: "Not started",
         specified: "Specified",
         planned: "Planned",
         implemented: "Implemented",
@@ -391,6 +392,7 @@ export const translations = {
         "Syötä arvo väliltä 0 ja 1 (esim. 0.75 = 75% valmis)",
       confirmDeleteMessage: "Oletko varma, että haluat poistaa komponentin",
       degreeOfCompletion: {
+        notStarted: "Ei aloitettu",
         specified: "Määritelty",
         planned: "Suunniteltu",
         implemented: "Toteutettu",


### PR DESCRIPTION
Lisäsin valmiusastevalikkoon 0 - ei aloitettu, sille käännökset sekä muokkasin valikkoa niin, että se hyväksyy 0 arvona. Numero 0 oli laskelmissa jo olemassa koska kaikki invalid arvot luetaan nollana joten niihin ei tarvinut koskea. 